### PR TITLE
Patched cinnamon-session detection

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -63,7 +63,7 @@ def linux_terminal():
     if wm:
         # elementary OS: `/usr/lib/gnome-session/gnome-session-binary --session=pantheon`
         # Gnome: `gnome-session` or `gnome-session-binary`
-        # Linux Mint Cinnamon: `cinnamon-sessio cinnamon-session --session cinnamon
+        # Linux Mint Cinnamon: `cinnamon-sessio cinnamon-session --session cinnamon`
         if wm[0].startswith('gnome-session') or wm[0].startswith('cinnamon-sessio'):
             if 'pantheon' in wm[0]:
                 return 'pantheon-terminal'

--- a/Terminal.py
+++ b/Terminal.py
@@ -63,8 +63,8 @@ def linux_terminal():
     if wm:
         # elementary OS: `/usr/lib/gnome-session/gnome-session-binary --session=pantheon`
         # Gnome: `gnome-session` or `gnome-session-binary`
-        # Linux Mint Cinnamon: `cinnamon-session --session cinnamon`
-        if wm[0].startswith('gnome-session') or wm[0].startswith('cinnamon-session'):
+        # Linux Mint Cinnamon: `cinnamon-sessio cinnamon-session --session cinnamon
+        if wm[0].startswith('gnome-session') or wm[0].startswith('cinnamon-sessio'):
             if 'pantheon' in wm[0]:
                 return 'pantheon-terminal'
             return 'gnome-terminal'


### PR DESCRIPTION
As reported in #1, Terminal detection for Linux Mint Cinnamon was broken. This PR fixes #1

In this PR:

- Updated relevant code + added comment