### PR TITLE
on mac terminal allow re-use of front-most window

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -110,7 +110,11 @@ class TerminalSelector():
                 default = os.environ['SYSTEMROOT'] + '\\System32\\cmd.exe'
 
         elif sys.platform == 'darwin':
-            default = os.path.join(package_dir, 'Terminal.sh')
+            script = 'Terminal.sh'
+            if get_setting('reuse_window', False):
+                script = 'TerminalReuse.sh'
+
+            default = os.path.join(package_dir, script)
             if not os.access(default, os.X_OK):
                 os.chmod(default, 0o755)
 

--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -12,5 +12,9 @@
 	// An environment variables changeset. Default environment variables used for the
 	// terminal are inherited from sublime. Use this mapping to overwrite/unset. Use
 	// null value to indicate that the environment variable should be unset.
-	"env": {}
+	"env": {},
+
+	// For the Mac Terminal.app only, allow reuse of the front-most window,
+	// instead of spawning a new window
+	"reuse_window": false
 }

--- a/TerminalReuse.sh
+++ b/TerminalReuse.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+CD_CMD="cd "\\\"$(pwd)\\\"""
+if echo "$SHELL" | grep -E "/fish$" &> /dev/null; then
+	CD_CMD="cd "\\\"$(pwd)\\\"""
+fi
+
+osascript<<END
+try
+	tell application "System Events"
+		tell application "Terminal"
+			activate
+		end tell
+		tell application "Terminal"
+			do script "$CD_CMD" in window 1
+		end tell
+	end tell
+end try
+END


### PR DESCRIPTION
The way I use Terminal it's a bit annoying that a new window is spawned every time. I end up with dozens of windows. Not sure if this should be a command argument, to be more flexible, or if a setting like this fits. It might also be applicable to different terminals.