### PR TITLE
use user's main keymap file

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -21,7 +21,6 @@
         "command": "edit_settings",
         "args": {
             "base_file": "${packages}/Terminal/Default ($platform).sublime-keymap",
-            "default": "[\n\t$0\n]\n"
         }
     },
     {

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -33,7 +33,6 @@
                                 "command": "edit_settings",
                                 "args": {
                                     "base_file": "${packages}/Terminal/Default ($platform).sublime-keymap",
-                                    "default": "[\n\t$0\n]\n"
                                 }
                             }
                         ]


### PR DESCRIPTION
By removing the default, open the user's (os-specific) key-map this keeps user keymaps in one place, making it easier to manage e.g. no more hunting several files to resolve conflicting bindings. I've seen more packages do it this way, and have personally also preferred having a single file on "my side" to manage potentially conflicting custom key bindings, move bindings from one package to another, etc.